### PR TITLE
Show text along with spinner, implementation of cli-spinners, and code update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
-Supper Simple Spinner for Node.js
-=================================
+# Supper Simple Spinner for Node.js
 
 This is a supper simple spinner / activity indicator for Node.js.
 I've used it in a few console tools that I've written in Node.js, where I've wanted to show that there is activity and that the program isn't hung.
 
 [![NPM](https://nodei.co/npm/simple-spinner.png?downloads=true)](https://nodei.co/npm/simple-spinner/)
 
-How Simple Is It?
------------------
+## Updates
 
-So simple it only has 3 functions.
+Now you can use a spinner from [cli-spinners](https://www.npmjs.com/package/cli-spinners) and use a text with the spinner.
 
- * `start([interval in ms], [options])`
-   * Obviously this starts the spinner. You can give it how quickly you want it to go through the sequence of characters. Defaults to 250ms.
-   * **Update (2015-07-24)**: start can now also take an options object with the following keys:
-     * `hideCursor` (boolean, default: false): When true, hide the console cursor (uses TooTallNate/ansi.js)
-     * `doNotBlock` (boolean, default: false): When true, unref the timer so it does not prevent the process from exiting. 
- * `stop()`
-   * I really shouldn't have to explain this one...
- * `change_sequence(sequence)`
-   * Use this if you don't like the default spinning stick. Give it an array of strings like this `[".", "o", "0", "@", "*"]`
+## How Simple Is It?
 
+So simple it only has 2 functions.
+
+-   `start([options])`
+    -   Obviously this starts the spinner.
+    -   **Options**: start can take an options object with the following keys:
+        -   `sequence` (string | array, default: "line"): If it is a string, expect the name of a [cli-spinners](https://www.npmjs.com/package/cli-spinners) spinner. The list of spinners can be reviewed at [cli-spinners JSON](https://github.com/sindresorhus/cli-spinners/blob/main/spinners.json). It it is a array, expect an array of strings like this [".", "o", "0", "@", "*"]
+        -   `interval` (integer, default: 250): Specify how to fast the sequence should go in milliseconds. If a spinner from [cli-spinners](https://www.npmjs.com/package/cli-spinners) is given and an interval is not specified, it will be taken from the information of the spinner in the [cli-spinners JSON](https://github.com/sindresorhus/cli-spinners/blob/main/spinners.json).
+        -   `hideCursor` (boolean, default: false): When true, hide the console cursor (uses TooTallNate/ansi.js)
+        -   `doNotBlock` (boolean, default: false): When true, unref the timer so it does not prevent the process from exiting.
+        -   `text` (string, default: ""): Text that will go along with the spinner.
+-   `stop()`
+    -   I really shouldn't have to explain this one...

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ So simple it only has 2 functions.
 -   `start([options])`
     -   Obviously this starts the spinner.
     -   **Options**: start can take an options object with the following keys:
-        -   `sequence` (string | array, default: "line"): If it is a string, expect the name of a [cli-spinners](https://www.npmjs.com/package/cli-spinners) spinner. The list of spinners can be reviewed at [cli-spinners JSON](https://github.com/sindresorhus/cli-spinners/blob/main/spinners.json). It it is a array, expect an array of strings like this [".", "o", "0", "@", "*"]
+        -   `sequence` (string | array, default: "line"): If it is a string, expect the name of a [cli-spinners](https://www.npmjs.com/package/cli-spinners) spinner. The list of spinners can be reviewed at [cli-spinners JSON](https://github.com/sindresorhus/cli-spinners/blob/main/spinners.json). If it is a array, expect an array of strings like this [".", "o", "0", "@", "*"]
         -   `interval` (integer, default: 250): Specify how to fast the sequence should go in milliseconds. If a spinner from [cli-spinners](https://www.npmjs.com/package/cli-spinners) is given and an interval is not specified, it will be taken from the information of the spinner in the [cli-spinners JSON](https://github.com/sindresorhus/cli-spinners/blob/main/spinners.json).
         -   `hideCursor` (boolean, default: false): When true, hide the console cursor (uses TooTallNate/ansi.js)
         -   `doNotBlock` (boolean, default: false): When true, unref the timer so it does not prevent the process from exiting.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "simple-spinner",
+  "version": "0.0.5",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "simple-spinner",
+      "version": "0.0.5",
+      "dependencies": {
+        "ansi": "^0.3.0"
+      }
+    },
+    "node_modules/ansi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A=="
+    }
+  },
+  "dependencies": {
+    "ansi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A=="
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,25 @@
       "name": "simple-spinner",
       "version": "0.0.5",
       "dependencies": {
-        "ansi": "^0.3.0"
+        "ansi": "^0.3.0",
+        "cli-spinners": "^2.8.0"
       }
     },
     "node_modules/ansi": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
       "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A=="
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.8.0.tgz",
+      "integrity": "sha512-/eG5sJcvEIwxcdYM86k5tPwn0MUzkX5YY3eImTGpJOZgVe4SdTMY14vQpcxgBzJ0wXwAYrS8E+c3uHeK4JNyzQ==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -22,6 +34,11 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
       "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A=="
+    },
+    "cli-spinners": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.8.0.tgz",
+      "integrity": "sha512-/eG5sJcvEIwxcdYM86k5tPwn0MUzkX5YY3eImTGpJOZgVe4SdTMY14vQpcxgBzJ0wXwAYrS8E+c3uHeK4JNyzQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,22 +1,25 @@
 {
-  "name": "simple-spinner",
-  "description": "A super simple spinner",
-  "keywords": [
-    "simple",
-    "spinner",
-    "indicator"
-  ],
-  "version": "0.0.5",
-  "licence": "MIT",
-  "author": "Ian McCall <imccall@da-puck.com> (http://www.ianmccall.codes/)",
-  "main": "./spinner",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/dapuck/node-simple-spinner.git"
-  },
-  "homepage": "https://github.com/dapuck/node-simple-spinner",
-  "dependencies": {
-    "ansi": "^0.3.0",
-    "cli-spinners": "^2.8.0"
-  }
+	"name": "simple-spinner",
+	"description": "A super simple spinner",
+	"keywords": [
+		"simple",
+		"spinner",
+		"indicator"
+	],
+	"version": "0.0.6",
+	"licence": "MIT",
+	"author": "Ian McCall <imccall@da-puck.com> (http://www.ianmccall.codes/)",
+	"contributors": [
+		"sgb004"
+	],
+	"main": "./spinner",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/dapuck/node-simple-spinner.git"
+	},
+	"homepage": "https://github.com/dapuck/node-simple-spinner",
+	"dependencies": {
+		"ansi": "^0.3.0",
+		"cli-spinners": "^2.8.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "homepage": "https://github.com/dapuck/node-simple-spinner",
   "dependencies": {
-    "ansi": "^0.3.0"
+    "ansi": "^0.3.0",
+    "cli-spinners": "^2.8.0"
   }
 }

--- a/spinner.js
+++ b/spinner.js
@@ -2,28 +2,36 @@
  * Spinner *
  ***********/
 const cursor = require('ansi')(process.stdout);
+const cliSpinners = require('cli-spinners');
+
 const spinner = (function () {
-	let sequence = ['||', '/', '-', '\\'];
-	let sequenceText;
+	let sequence;
 	let index = 0;
 	let timer;
 	let opts = {};
 
-	function start(inv = 250, options = {}) {
-		opts = { hideCursor: false, doNotBlock: false, text: '', ...options };
+	function start(options = {}) {
+		opts = {
+			sequence: 'line',
+			interval: 250,
+			hideCursor: false,
+			doNotBlock: false,
+			text: '',
+			...options,
+		};
 
 		if (opts.hideCursor) cursor.hide();
 
-		sequenceText = addTextSequence();
+		sequence = addTextSequence();
 
 		index = 0;
-		process.stdout.write(sequenceText[index]);
+		process.stdout.write(sequence[index]);
 
 		timer = setInterval(function () {
 			clearLine();
-			index = index < sequenceText.length - 1 ? index + 1 : 0;
-			process.stdout.write(sequenceText[index]);
-		}, inv);
+			index = index < sequence.length - 1 ? index + 1 : 0;
+			process.stdout.write(sequence[index]);
+		}, opts.interval);
 
 		if (opts.doNotBlock) timer.unref();
 	}
@@ -38,28 +46,26 @@ const spinner = (function () {
 		clearLine();
 	}
 
-	function changeSequence(seq) {
-		if (Array.isArray(seq)) {
-			sequence = seq;
-			sequenceText = addTextSequence();
-		} else {
-			throw new Error('Sequence must be an array');
-		}
-	}
-
 	function clearLine() {
-		process.stdout.write(sequenceText[index].replace(/./g, '\b'));
+		process.stdout.write(sequence[index].replace(/./g, '\b'));
 		process.stdout.clearLine();
 	}
 
 	function addTextSequence() {
+		let sequence = [];
+		if (Array.isArray(opts.sequence)) {
+			sequence = opts.sequence;
+		} else {
+			if (cliSpinners[opts.sequence] == undefined) throw new Error('Spinner not found');
+			sequence = cliSpinners[opts.sequence].frames;
+		}
+		if (sequence.length == 0) throw new Error('Spinner is empty');
 		return opts.text ? sequence.map((character) => character + ' ' + opts.text) : sequence;
 	}
 
 	return {
 		start,
 		stop,
-		changeSequence,
 	};
 })();
 

--- a/spinner.js
+++ b/spinner.js
@@ -11,9 +11,11 @@ const spinner = (function () {
 	let opts = {};
 
 	function start(options = {}) {
+		let interval;
+
 		opts = {
 			sequence: 'line',
-			interval: 250,
+			interval: 0,
 			hideCursor: false,
 			doNotBlock: false,
 			text: '',
@@ -21,9 +23,7 @@ const spinner = (function () {
 		};
 
 		if (opts.hideCursor) cursor.hide();
-
-		sequence = addTextSequence();
-
+		interval = buildSequence(opts.interval);
 		index = 0;
 		process.stdout.write(sequence[index]);
 
@@ -31,7 +31,7 @@ const spinner = (function () {
 			clearLine();
 			index = index < sequence.length - 1 ? index + 1 : 0;
 			process.stdout.write(sequence[index]);
-		}, opts.interval);
+		}, interval);
 
 		if (opts.doNotBlock) timer.unref();
 	}
@@ -51,16 +51,21 @@ const spinner = (function () {
 		process.stdout.clearLine();
 	}
 
-	function addTextSequence() {
-		let sequence = [];
+	function buildSequence(interval) {
 		if (Array.isArray(opts.sequence)) {
 			sequence = opts.sequence;
 		} else {
-			if (cliSpinners[opts.sequence] == undefined) throw new Error('Spinner not found');
-			sequence = cliSpinners[opts.sequence].frames;
+			const cliSpinner = cliSpinners[opts.sequence];
+			if (cliSpinner == undefined) throw new Error('Spinner not found');
+			sequence = cliSpinner.frames;
+			if (interval == 0) interval = cliSpinner.interval;
 		}
+
 		if (sequence.length == 0) throw new Error('Spinner is empty');
-		return opts.text ? sequence.map((character) => character + ' ' + opts.text) : sequence;
+		sequence = opts.text ? sequence.map((character) => character + ' ' + opts.text) : sequence;
+
+		if (interval == 0) interval = 250;
+		return interval;
 	}
 
 	return {

--- a/test.js
+++ b/test.js
@@ -21,6 +21,15 @@ function test3() {
 	spinner.start(50, { hideCursor: true });
 	setTimeout(function () {
 		spinner.stop();
+		test4();
+	}, 1000);
+}
+
+function test4() {
+	spinner.changeSequence(['|', '/', '-', '\\']);
+	spinner.start(100, { text: 'Loading...' });
+	setTimeout(function () {
+		spinner.stop();
 		spinner.start(100, { doNotBlock: true });
 	}, 1000);
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-var spinner = require('./spinner');
+const spinner = require('./spinner');
 
 function test1() {
 	spinner.start();

--- a/test.js
+++ b/test.js
@@ -9,8 +9,7 @@ function test1() {
 }
 
 function test2() {
-	spinner.changeSequence(['0o0', 'o0o']);
-	spinner.start();
+	spinner.start({ sequence: ['0o0', 'o0o'] });
 	setTimeout(function () {
 		spinner.stop();
 		test3();
@@ -18,7 +17,7 @@ function test2() {
 }
 
 function test3() {
-	spinner.start(50, { hideCursor: true });
+	spinner.start({ sequence: ['0o0', 'o0o'], interval: 50, hideCursor: true });
 	setTimeout(function () {
 		spinner.stop();
 		test4();
@@ -26,12 +25,11 @@ function test3() {
 }
 
 function test4() {
-	spinner.changeSequence(['|', '/', '-', '\\']);
-	spinner.start(100, { text: 'Loading...' });
+	spinner.start({ sequence: 'dots', interval: 80, text: 'Loading...' });
 	setTimeout(function () {
 		spinner.stop();
-		spinner.start(100, { doNotBlock: true });
-	}, 1000);
+		spinner.start({ interval: 100, doNotBlock: true });
+	}, 1500);
 }
 
 process.on('exit', function () {

--- a/test.js
+++ b/test.js
@@ -1,33 +1,33 @@
 var spinner = require('./spinner');
 
 function test1() {
-  spinner.start();
-  setTimeout(function() {
-    spinner.stop();
-    test2();
-  }, 1000);
+	spinner.start();
+	setTimeout(function () {
+		spinner.stop();
+		test2();
+	}, 1000);
 }
 
 function test2() {
-  spinner.change_sequence(["0o0", "o0o"]);
-  spinner.start();
-  setTimeout(function() {
-    spinner.stop();
-    test3();
-  }, 1000);
+	spinner.changeSequence(['0o0', 'o0o']);
+	spinner.start();
+	setTimeout(function () {
+		spinner.stop();
+		test3();
+	}, 1000);
 }
 
 function test3() {
-  spinner.start(50,{ hideCursor : true });
-  setTimeout(function() {
-    spinner.stop();
-    spinner.start(100, { doNotBlock : true });
-  }, 1000);
+	spinner.start(50, { hideCursor: true });
+	setTimeout(function () {
+		spinner.stop();
+		spinner.start(100, { doNotBlock: true });
+	}, 1000);
 }
 
-process.on("exit", function() {
-  spinner.stop();
-  console.log("Have a nice day");
+process.on('exit', function () {
+	spinner.stop();
+	console.log('Have a nice day');
 });
 
 test1();


### PR DESCRIPTION
At first, I only wanted to add the ability to display text alongside the spinner, but ended up updating the code by making simple changes such as replacing 'var' with 'const' or 'let'. Later, I thought it would be beneficial for the plugin to have the option of choosing a spinner from the cli-spinners library (https://github.com/sindresorhus/cli-spinners), so I made some changes to enable the selection of a spinner from that library.

Other changes I made included removing the 'change_sequence' function and moving the sequence change to the 'start' function, as I thought it would be simpler that way. Additionally, I moved the interval within the options of the 'start' function.